### PR TITLE
Add missing method to FileInfoInterface + Type Checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
-# Upload 2.0.1
+# Upload 3.0.0
 
-## Bug Fixes
+## Breaking Changes
 
-* Revert removal of `\GravityPdf\Upload\File::__call()` magic method in 2.0.0. 
+* Revert removal of `\GravityPdf\Upload\File::__call()` magic method in 2.0.0, restoring API functionality to match v1
+* Add `setNameWithExtension()` method to `\GravityPdf\Upload\FileInfoInterface`
+* Change type signature `\GravityPdf\Upload\FileInfoInterface::setName(string $name)` 
+* Change type signature `\GravityPdf\Upload\FileInfoInterface::setExtension(string $extension)`
 
 # Upload 2.0.0
 

--- a/src/Upload/FileInfo.php
+++ b/src/Upload/FileInfo.php
@@ -131,7 +131,7 @@ class FileInfo extends SplFileInfo implements FileInfoInterface
      * @internal 3. URI reserved https://www.rfc-editor.org/rfc/rfc3986#section-2.2
      * @internal 4. URL unsafe characters https://www.ietf.org/rfc/rfc1738.txt
      */
-    public function setName($name): FileInfo
+    public function setName(string $name): FileInfo
     {
         $this->name = $this->sanitizeName($name);
 
@@ -215,7 +215,7 @@ class FileInfo extends SplFileInfo implements FileInfoInterface
      * @param string $extension
      * @return FileInfo Self
      */
-    public function setExtension($extension): FileInfo
+    public function setExtension(string $extension): FileInfo
     {
         $extension = strtolower($extension);
         $extension = trim((string)preg_replace('/[^a-z0-9]/', '', $extension));

--- a/src/Upload/FileInfoInterface.php
+++ b/src/Upload/FileInfoInterface.php
@@ -54,7 +54,7 @@ interface FileInfoInterface
      * @param string $name
      * @return FileInfo
      */
-    public function setName($name): FileInfo;
+    public function setName(string $name): FileInfo;
 
     public function getExtension(): string;
 
@@ -62,9 +62,11 @@ interface FileInfoInterface
      * @param string $extension
      * @return FileInfo
      */
-    public function setExtension($extension): FileInfo;
+    public function setExtension(string $extension): FileInfo;
 
     public function getNameWithExtension(): string;
+
+    public function setNameWithExtension(string $filename): FileInfo;
 
     public function getMimetype(): string;
 


### PR DESCRIPTION
## Description

Add overlooked changes to the FileInfoInterface contract, like `setNameWithExtension()` and strict type checking on `addName` and `addExtension`

## Testing instructions
Automated tests

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code
- [x] I've written unit tests for new features (where appropriate)
- [x] My code is easy to read, follow, and understand
- [x] My code has proper inline documentation / docblocks.

## Additional Comments <!-- if applicable -->

Because v2.0 was already tagged and published, and as this is a breaking change, the version number has been bumped to 3.0.