### PR TITLE
Resolve ArrayAccess deprecation warning in PHP 8.1

### DIFF
--- a/src/Upload/File.php
+++ b/src/Upload/File.php
@@ -438,21 +438,39 @@ class File implements ArrayAccess, IteratorAggregate, Countable
      * Array Access Interface
      *******************************************************************************/
 
+    /**
+     * @param mixed $offset
+     * @return bool
+     */
     public function offsetExists($offset): bool
     {
         return isset($this->objects[$offset]);
     }
 
+    /**
+     * @param mixed $offset
+     * @return FileInfoInterface|null
+     */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->objects[$offset] ?? null;
     }
 
+    /**
+     * @param mixed $offset
+     * @param FileInfoInterface $value
+     * @return void
+     */
     public function offsetSet($offset, $value): void
     {
         $this->objects[$offset] = $value;
     }
 
+    /**
+     * @param mixed $offset
+     * @return void
+     */
     public function offsetUnset($offset): void
     {
         unset($this->objects[$offset]);


### PR DESCRIPTION
## Description

As the library supports PHP7-8.0, this PR implements the #[\ReturnTypeWillChange] attribute on offsetGet() to temporarily suppress the notice. Appropriate docblocks have been added to the ArrayAccess methods as well.

## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [ ] I've tested the code
- [ ] I've written unit tests for new features (where appropriate)
- [ ] My code is easy to read, follow, and understand
- [ ] My code has proper inline documentation / docblocks.

## Additional Comments <!-- if applicable -->
